### PR TITLE
feat: Use exclusive the 'sequelize' in _LaboratoryTests and _TypeOfSamples

### DIFF
--- a/api/app/models/index.js
+++ b/api/app/models/index.js
@@ -10,8 +10,8 @@ const sequelize = new Sequelize(
     port: dbConfig.PORT,
     dialect: dbConfig.dialect,
     operatorsAliases: false,
-    username:dbConfig.USER,
-    password:dbConfig.PASSWORD,
+    username: dbConfig.USER,
+    password: dbConfig.PASSWORD,
     pool: {
       max: dbConfig.pool.max,
       min: dbConfig.pool.min,
@@ -30,20 +30,20 @@ db.log = require('../models/log.model.js')(sequelize, Sequelize);
 db.user = require('../models/user.model.js')(sequelize, Sequelize);
 db.role = require('../models/role.model.js')(sequelize, Sequelize);
 db.medicalCenter = require('../models/medicalCenter.model.js')(sequelize, Sequelize);
-db.state = require('../models/state.model.js')(sequelize,Sequelize);
-db.city = require('../models/city.model.js')(sequelize,Sequelize);
-db.patientPet = require('../models/patientPet.model.js')(sequelize,Sequelize);
-db.petOwner = require('../models/petOwner.model.js')(sequelize,Sequelize);
-db.species = require('./species.model.js')(sequelize,Sequelize);
-db.breed = require('../models/breed.model.js')(sequelize,Sequelize);
-db.patientExam = require('../models/patientExam.model.js')(sequelize,Sequelize);
+db.state = require('../models/state.model.js')(sequelize, Sequelize);
+db.city = require('../models/city.model.js')(sequelize, Sequelize);
+db.patientPet = require('../models/patientPet.model.js')(sequelize, Sequelize);
+db.petOwner = require('../models/petOwner.model.js')(sequelize, Sequelize);
+db.species = require('./species.model.js')(sequelize, Sequelize);
+db.breed = require('../models/breed.model.js')(sequelize, Sequelize);
+db.patientExam = require('../models/patientExam.model.js')(sequelize, Sequelize);
 db.laboratoryTest = require('../models/laboratoryTest.model.js')(sequelize, Sequelize);
 db.typeOfSample = require('./typeOfSample.model.js')(sequelize, Sequelize);
 db.veterinarian = require('../models/veterinarian.model.js')(sequelize, Sequelize);
 db.testType = require('../models/testType.model.js')(sequelize, Sequelize);
 
 /*============== user_roles =============== */
-db.user_roles = require('../models/user_roles.model.js')(sequelize, Sequelize);
+db.user_roles = require('./user_Roles.model.js')(sequelize, Sequelize);
 db.role.belongsToMany(db.user, {
   through: 'user_roles',
   foreignKey: 'roleId',
@@ -57,7 +57,7 @@ db.user.belongsToMany(db.role, {
 });
 
 /*=========== user_medicalCenters ============ */
-db.user_medicalCenters = require('../models/user_medicalCenters.model.js')(sequelize, Sequelize);
+db.user_medicalCenters = require('./user_MedicalCenters.model.js')(sequelize, Sequelize);
 db.medicalCenter.belongsToMany(db.user, {
   through: 'user_medicalCenters',
   foreignKey: 'medicalCenterId',
@@ -70,6 +70,7 @@ db.user.belongsToMany(db.medicalCenter, {
   otherKey: 'medicalCenterId'
 });
 /*======== PatientExam_TypeOfSamples ========= */
+db.patientExam_TypeOfSamples = require('./patientExam_TypeOfSamples.model.js')(sequelize, Sequelize);
 db.patientExam.belongsToMany(db.typeOfSample, {
   through: 'PatientExam_TypeOfSamples',
   foreignKey: 'patientExamId',
@@ -83,6 +84,7 @@ db.typeOfSample.belongsToMany(db.patientExam, {
 });
 
 /*======== PatientExam_LaboratoryTests ========= */
+db.patientExam_LaboratoryTests = require('./patientExam_LaboratoryTests.model.js')(sequelize, Sequelize);
 db.patientExam.belongsToMany(db.laboratoryTest, {
   through: 'PatientExam_LaboratoryTests',
   foreignKey: 'patientExamId',

--- a/api/app/models/patientExam_LaboratoryTests.model.js
+++ b/api/app/models/patientExam_LaboratoryTests.model.js
@@ -1,0 +1,5 @@
+module.exports = (sequelize, Sequelize) => {
+  const patientExam_LaboratoryTests = sequelize.define('patientexam_laboratorytests');
+
+  return patientExam_LaboratoryTests;
+};

--- a/api/app/models/patientExam_TypeOfSamples.model.js
+++ b/api/app/models/patientExam_TypeOfSamples.model.js
@@ -1,0 +1,5 @@
+module.exports = (sequelize, Sequelize) => {
+  const patientExam_TypeOfSamples = sequelize.define('patientexam_typeofsamples');
+
+  return patientExam_TypeOfSamples;
+};

--- a/api/app/routes/breed.routes.js
+++ b/api/app/routes/breed.routes.js
@@ -3,42 +3,53 @@ const express = require("express");
 // Import middlewares
 const auth = require("../middleware/auth.js");
 const { admin, laboratory, clinic } = require("../middleware/roles.js");
-const mysqlConnection = require("../utils/database.js");
+const db = require("../models");
 const apiMessage = require("../utils/messages.js");
+const setLog = require("../utils/logs.utils.js")
 
 // Setup the express server routeRoles
 const routeBreed = express.Router();
 
 routeBreed.get("/api/breed/:id", [auth, clinic], (request, response) => {
+  var values = [parseInt(String(request.params.id))];
+  const funcName = arguments.callee.name + "routeBreed.get(";
+  const apiUrl = "/api/breed/:";
+  setLog("TRACE", __filename, funcName, `${apiUrl}${JSON.stringify(values)}`);
   var query = `SELECT breedId,breedName,IF(MOD(breedId,1000)=1,0,1) as breedSort, SpeciesSpeciesId  
             FROM ${process.env.MYSQL_D_B_}.Breeds
-            WHERE SpeciesSpeciesId = ?
+            WHERE SpeciesSpeciesId = :speciesId
             ORDER BY breedSort,breedName`;
-  var values = [parseInt(request.params.id)];
-  mysqlConnection.getConnection(function (err, connection) {
-    if (err) {
-      response.status(501).json({
-        message: apiMessage["501"][1],
-        ok: false,
-        error: err,
-      });
-      return;
-    }
-    mysqlConnection.query(query, values, (err, rows, fields) => {
-      connection.release();
-      if (err) {
+  if (!values) {
+    setLog("ERROR", __filename, funcName, `${apiUrl}:${JSON.stringify(values)}`);
+    response.status(400).json({
+      message: apiMessage["400"][1],
+      ok: false,
+      errors: validationResponse,
+    });
+  } else {
+    setLog("TRACE", __filename, funcName, `${apiUrl}${query}`);
+    db.sequelize
+      .query(query, {
+        replacements: { speciesId: values },
+        type: QueryTypes.SELECT,
+      })
+      .then((rows)=>{
+        setLog("DEBUG",__filename,funcName,`${apiUrl}.rows:${JSON.stringify(rows)}`);
+        response.send(rows)
+      })
+      .catch((err)=>{
         response.status(501).json({
           message: apiMessage["501"][1],
           ok: false,
           error: err,
         });
-      }
-      response.send(rows);
-    });
-    connection.on("error", function (err) {
-      return;
-    });
-  });
+        setLog("ERROR", __filename, funcName, JSON.stringify(err));
+      })
+      .finally(()=>{
+        setLog("INFO",__filename,funcName,`(${apiUrl}${JSON.stringify(values)}).end`);
+      });
+  }
+
   // To Test in Postman use a GET with this URL "http://localhost:49146/api/employee"
   // in "Body" use none
 });

--- a/api/app/routes/city.routes.js
+++ b/api/app/routes/city.routes.js
@@ -18,7 +18,7 @@ routeCity.get("/api/city/:id", (request, response) => {
             WHERE StateStateId = :stateId
             ORDER BY citySort, cityName`;
   if (!values) {
-    setLog("ERROR",__filename,funcName,`${apiUrl}:${JSON.stringify(values)}`);
+    setLog("ERROR", __filename, funcName, `${apiUrl}${JSON.stringify(values)}`);
     response.status(400).json({
       message: apiMessage["400"][1],
       ok: false,
@@ -32,7 +32,7 @@ routeCity.get("/api/city/:id", (request, response) => {
         type: QueryTypes.SELECT,
       })
       .then((rows) => {
-        setLog("DEBUG",__filename,funcName,`${apiUrl}.rows:${JSON.stringify(rows)}`);
+        setLog("DEBUG", __filename, funcName, `${apiUrl}.rows:${JSON.stringify(rows)}`);
         response.send(rows);
       })
       .catch((err) => {
@@ -43,9 +43,7 @@ routeCity.get("/api/city/:id", (request, response) => {
         });
         setLog("ERROR", __filename, funcName, JSON.stringify(err));
       })
-      .finally(() => {
-        setLog("INFO",__filename,funcName,`(/api/city/:${JSON.stringify(values)}).end`);
-      });
+      .finally(() => { setLog("INFO", __filename, funcName, `(${apiUrl}${JSON.stringify(values)}).end`); });
   }
 
   // To Test in Postman use a GET with this URL "http://localhost:49146/api/employee"

--- a/api/app/routes/laboratoryTest.routes.js
+++ b/api/app/routes/laboratoryTest.routes.js
@@ -1,45 +1,53 @@
 const express = require('express');
+const { Op } = require("sequelize");
 
 // Import middlewares
 const auth = require('../middleware/auth.js');
 const { admin, laboratory, clinic } = require('../middleware/roles.js');
-const mysqlConnection = require('../utils/database.js');
+const db = require("../models");
 const apiMessage = require('../utils/messages.js');
+const setLog = require("../utils/logs.utils.js");
 
 // Setup the express server routeRoles
 const routeLaboratoryTest = express.Router();
 
 routeLaboratoryTest.get('/api/laboratorytest/:id', [auth, clinic], async (request, response) => {
-  var query = `SELECT laboratoryTestId, laboratoryTestName, TestTypeTestTypeId FROM ${process.env.MYSQL_D_B_}.laboratoryTests
-            WHERE laboratoryTestId >0 AND TestTypeTestTypeId=?
-            ORDER BY TestTypeTestTypeId,laboratoryTestName`;
-  var values = [
-    parseInt(request.params.id)
-  ];
-  mysqlConnection.getConnection(function (err, connection) {
-    if (err) {
-      response.status(501).json({
-        message: apiMessage["501"][1],
-        ok: false,
-        error: err,
-      });
-      return;
-    }
-  mysqlConnection.query(query, values, (err, rows, fields) => {
-    connection.release();
-    if (err) {
-      response.status(501).json({
-        message: apiMessage['501'][1],
-        ok: false,
-        error: err
-      });
-    }
-    response.send(rows);
-  });
-  connection.on("error", function (err) {
-    return;
-  });
-});
+  const funcName = arguments.callee.name + "routeLaboratoryTest.get(";
+  const apiUrl = "/api/laboratorytest/:";
+  var jsonValues = { TestTypeTestTypeId: parseInt(request.params.id) };
+  setLog("TRACE", __filename, funcName, `${apiUrl}${JSON.stringify(jsonValues)}`);
+  // var query = `SELECT laboratoryTestId, laboratoryTestName, TestTypeTestTypeId FROM ${process.env.MYSQL_D_B_}.laboratoryTests WHERE laboratoryTestId >0 AND TestTypeTestTypeId=? ORDER BY TestTypeTestTypeId,laboratoryTestName`;
+  if (!jsonValues.TestTypeTestTypeId) {
+    setLog("ERROR", __filename, funcName, `${apiUrl}${JSON.stringify(jsonValues)}`);
+    response.status(400).json({
+      message: apiMessage["400"][1],
+      ok: false,
+      errors: validationResponse,
+    });
+  } else {
+    db.laboratoryTest.findAll({
+      attributes: ["laboratoryTestId", "laboratoryTestName", "TestTypeTestTypeId"],
+      where: {
+        [Op.and]: [{ TestTypeTestTypeId: jsonValues.TestTypeTestTypeId },
+        { laboratoryTestId: { [Op.gt]: 0 } } /*>0*/]
+      },
+      order: [['TestTypeTestTypeId', 'ASC'],
+      ['laboratoryTestName', 'ASC'],],
+    }).then((rows) => {
+      setLog("DEBUG", __filename, funcName, `${apiUrl}.rows:${JSON.stringify(rows)}`);
+      response.send(rows);
+    })
+      .catch((err) => {
+        response.status(501).json({
+          message: apiMessage['501'][1],
+          ok: false,
+          error: err
+        });
+        setLog("ERROR", __filename, funcName, JSON.stringify(err));
+      })
+      .finally(() => { setLog("INFO", __filename, funcName, `(${apiUrl}).end`); });
+  }
+
   // To Test in Postman use a GET with this URL "http://localhost:49146/api/employee"
   // in "Body" use none
 });

--- a/api/app/routes/patientexam_laboratorytest.routes.js
+++ b/api/app/routes/patientexam_laboratorytest.routes.js
@@ -2,7 +2,7 @@ const express = require("express");
 
 // Import middlewares
 const auth = require("../middleware/auth.js");
-const mysqlConnection = require("../utils/database.js");
+const db = require("../models");
 const apiMessage = require("../utils/messages.js");
 const { admin, laboratory, clinic } = require("../middleware/roles.js");
 const setLog = require("../utils/logs.utils.js");
@@ -10,58 +10,58 @@ const setLog = require("../utils/logs.utils.js");
 // Setup the express server routeRoles
 const routePatientexam_Laboratorytest = express.Router();
 
-routePatientexam_Laboratorytest.post(
-  "/api/patientexam_laboratorytest",
-  [auth, clinic],
-  (request, response) => {
-    
-    var query = `DELETE FROM ${process.env.MYSQL_D_B_}.patientexam_laboratorytests
-            WHERE patientExamId = ?`;
-    var values = [parseInt(request.body["patientExamId"])];
-    setLog("TRACE",__filename,arguments.callee.name+'routePatientexam_Laboratorytest.post', `/api/patientexam_laboratorytest ${JSON.stringify(values)}`);
-    mysqlConnection.getConnection(function (err, connection) {
-      if (err) {
-        response.status(501).json({
-          message: apiMessage["501"][1],
-          ok: false,
-          error: err,
-        });
-        return;
-      }
-      mysqlConnection.query(query, values, (err, rows, fields) => {
-        connection.release();
-        if (err) {
-          response.status(501).json({
-            message: apiMessage["501"][1],
-            ok: false,
-            error: err,
-          });
-        }
+routePatientexam_Laboratorytest.post("/api/patientexam_laboratorytest", [auth, clinic], (request, response) => {
+  const funcName = arguments.callee.name + "routePatientexam_Laboratorytest.post(";
+  const apiUrl = "/api/patientexam_laboratorytest|";
+  var jsonValues = {
+    patientExamId: parseInt(String(request.body["patientExamId"])),
+  };
+  setLog("TRACE", __filename, funcName, `${apiUrl}${JSON.stringify(jsonValues)}`);
+  // var query = `DELETE FROM ${process.env.MYSQL_D_B_}.patientexam_laboratorytests WHERE patientExamId = ?`;
+  if (!jsonValues.patientExamId) {
+    setLog("ERROR", __filename, funcName, `${apiUrl}${JSON.stringify(jsonValues)}`);
+    response.status(400).json({
+      message: apiMessage["400"][1],
+      ok: false,
+      errors: validationResponse,
+    });
+  } else {
+    db.patientExam_LaboratoryTests.destroy({
+      where: { jsonValues }
+    })
+      .then((rows) => {
         var arrLabTests = request.body["arrLabTests"];
-        query = `INSERT into ${process.env.MYSQL_D_B_}.patientexam_laboratorytests
-    (createdAt, updatedAt, patientExamId, laboratoryTestId)
-    VALUE (NOW(), NOW(), ?, ?)`;
+        setLog("TRACE", __filename, funcName, `${apiUrl}.arrLabTests:${arrLabTests}.rows:${rows}`);
+        // query = `INSERT into ${process.env.MYSQL_D_B_}.patientexam_laboratorytests (createdAt, updatedAt, patientExamId, laboratoryTestId) VALUE (NOW(), NOW(), ?, ?)`;
         for (var i = 0; i < arrLabTests.length; i++) {
-          values = [request.body["patientExamId"], parseInt(arrLabTests[i])];
-          mysqlConnection.query(query, values, (err, rows, fields) => {
-            if (err) {
-              setLog("ERROR",__filename,arguments.callee.name+'routePatientexam_Laboratorytest.post',JSON.stringify(err));
+          jsonValues['laboratoryTestId'] = parseInt(arrLabTests[i]); //{patientExamId: X, laboratoryTestId: Y}
+          db.patientExam_LaboratoryTests.create(
+            jsonValues
+          ).then((rows) => { setLog("TRACE", __filename, funcName, `${apiUrl}.created:${JSON.stringify(jsonValues)}.rows:${rows}`); })
+            .catch((err) => {
+              setLog("ERROR", __filename, funcName, `${apiUrl}.creating:${JSON.stringify(jsonValues)}.error:${JSON.stringify(err)}`);
               response.status(501).json({
                 message: apiMessage["501"][1],
                 ok: false,
                 error: err,
               });
-            }
-          });
+            })
+            .finally(() => { setLog("INFO", __filename, funcName, `(${apiUrl}.created:${JSON.stringify(jsonValues)}).end`); });
         }
-      });
-      connection.on("error", function (err) {
-        return;
-      });
-    });
-    // To Test in Postman use a POST with this URL "http://localhost:49146/api/patientexam_laboratorytest"
-    // in "Body" use patientExamId (numeric), laboratoryTestIds (array of string)
+      })
+      .catch((err) => {
+        response.status(501).json({
+          message: apiMessage["501"][1],
+          ok: false,
+          error: err,
+        });
+        setLog("ERROR", __filename, funcName, JSON.stringify(err));
+      })
+      .finally(() => { setLog("INFO", __filename, funcName, `(${apiUrl}).end`); });
   }
-);
+
+  // To Test in Postman use a POST with this URL "http://localhost:49146/api/patientexam_laboratorytest"
+  // in "Body" use patientExamId (numeric), laboratoryTestIds (array of string)
+});
 
 module.exports = routePatientexam_Laboratorytest;

--- a/api/app/routes/patientexam_typeofsample.routes.js
+++ b/api/app/routes/patientexam_typeofsample.routes.js
@@ -2,7 +2,7 @@ const express = require("express");
 
 // Import middlewares
 const auth = require("../middleware/auth.js");
-const mysqlConnection = require("../utils/database.js");
+const db = require("../models");
 const apiMessage = require("../utils/messages.js");
 const { admin, laboratory, clinic } = require("../middleware/roles.js");
 const setLog = require("../utils/logs.utils.js");
@@ -10,60 +10,58 @@ const setLog = require("../utils/logs.utils.js");
 // Setup the express server routeRoles
 const routePatientexam_TypeOfSample = express.Router();
 
-routePatientexam_TypeOfSample.post(
-  "/api/patientexam_typeofsample",
-  [auth, clinic],
-  (request, response) => {
-    var query = `DELETE FROM ${process.env.MYSQL_D_B_}.patientexam_typeofsamples
-            WHERE patientExamId = ?`;
-    var values = [parseInt(request.body["patientExamId"])];
-    setLog("TRACE",__filename,arguments.callee.name+'routePatientexam_TypeOfSample.post',`/api/patientexam_typeofsample ${JSON.stringify(values)}`);
-    mysqlConnection.getConnection(function (err, connection) {
-      if (err) {
-        response.status(501).json({
-          message: apiMessage["501"][1],
-          ok: false,
-          error: err,
-        });
-        return;
-      }
-      mysqlConnection.query(query, values, (err, rows, fields) => {
-        connection.release();
-        if (err) {
-          response.status(501).json({
-            message: apiMessage["501"][1],
-            ok: false,
-            error: err,
-          });
-        }
+routePatientexam_TypeOfSample.post("/api/patientexam_typeofsample", [auth, clinic], (request, response) => {
+  const funcName = arguments.callee.name + "routePatientexam_TypeOfSample.post(";
+  const apiUrl = "/api/patientexam_typeofsample|";
+  var jsonValues = {
+    patientExamId: parseInt(String(request.body["patientExamId"])),
+  };
+  setLog("TRACE", __filename, funcName, `${apiUrl}${JSON.stringify(jsonValues)}`);
+  // var query = `DELETE FROM ${process.env.MYSQL_D_B_}.patientexam_typeofsamples  WHERE patientExamId = ?`;
+  if (!jsonValues.patientExamId) {
+    setLog("ERROR", __filename, funcName, `${apiUrl}${JSON.stringify(jsonValues)}`);
+    response.status(400).json({
+      message: apiMessage["400"][1],
+      ok: false,
+      errors: validationResponse,
+    });
+  } else {
+    db.patientExam_TypeOfSamples.destroy({
+      where: { jsonValues }
+    })
+      .then((rows) => {
         var arrTypeOfSamples = request.body["arrTypeOfSamples"];
-        query = `INSERT into ${process.env.MYSQL_D_B_}.patientexam_typeofsamples
-    (createdAt, updatedAt, patientExamId, typeOfSampleId)
-    VALUE (NOW(), NOW(), ?, ?)`;
+        setLog("TRACE", __filename, funcName, `${apiUrl}.arrTypeOfSamples:${arrTypeOfSamples}.rows:${rows}`);
+        // query = `INSERT into ${process.env.MYSQL_D_B_}.patientexam_typeofsamples (createdAt, updatedAt, patientExamId, typeOfSampleId)  VALUE (NOW(), NOW(), ?, ?)`;
         for (var i = 0; i < arrTypeOfSamples.length; i++) {
-          values = [
-            request.body["patientExamId"],
-            parseInt(arrTypeOfSamples[i]),
-          ];
-          mysqlConnection.query(query, values, (err, rows, fields) => {
-            if (err) {
-              setLog("ERROR",__filename,arguments.callee.name+'routePatientexam_TypeOfSample.post',JSON.stringify(err));
+          jsonValues['typeOfSampleId'] = parseInt(arrTypeOfSamples[i]); //{patientExamId: X, typeOfSampleId: Y}
+          db.patientExam_TypeOfSamples.create(
+            jsonValues
+          ).then((rows) => { setLog("TRACE", __filename, funcName, `${apiUrl}.created:${JSON.stringify(jsonValues)}.rows:${rows}`); })
+            .catch((err) => {
+              setLog("ERROR", __filename, funcName, `${apiUrl}.creating:${JSON.stringify(jsonValues)}.error:${JSON.stringify(err)}`);
               response.status(501).json({
                 message: apiMessage["501"][1],
                 ok: false,
                 error: err,
               });
-            }
-          });
+            })
+            .finally(() => { setLog("INFO", __filename, funcName, `(${apiUrl}.created:${JSON.stringify(jsonValues)}).end`); });
         }
-      });
-      connection.on("error", function (err) {
-        return;
-      });
-    });
-    // To Test in Postman use a POST with this URL "http://localhost:49146/api/patientexam_typeofsample"
-    // in "Body" use patientExamId (numeric), laboratoryTestIds (array of string)
+      })
+      .catch((err) => {
+        response.status(501).json({
+          message: apiMessage["501"][1],
+          ok: false,
+          error: err,
+        });
+        setLog("ERROR", __filename, funcName, JSON.stringify(err));
+      })
+      .finally(() => { setLog("INFO", __filename, funcName, `(${apiUrl}).end`); });
   }
-);
+
+  // To Test in Postman use a POST with this URL "http://localhost:49146/api/patientexam_typeofsample"
+  // in "Body" use patientExamId (numeric), laboratoryTestIds (array of string)
+});
 
 module.exports = routePatientexam_TypeOfSample;


### PR DESCRIPTION
- 'sequelize' in 'patientexam_typeofsamples.routes instead of 'mysqlConnection'.
- 'sequelize' in 'patientexam_typeofsamples.routes' instead of 'mysqlConnection'.
- Adding 'patientExam_TypeOfSamples.model' and 'patientExam_TypeOfSamples.model'.
- Calling in 'model/index' first the new models before the 'belongsToMany'.

#20230821a