### PR TITLE
feat: Use exclusive the 'sequelize' in testTypes.routes and typeOfSample.routes

### DIFF
--- a/api/app/routes/species.routes.js
+++ b/api/app/routes/species.routes.js
@@ -3,39 +3,37 @@ const express = require("express");
 // Import middlewares
 const auth = require("../middleware/auth.js");
 const { admin, laboratory, clinic } = require("../middleware/roles.js");
-const mysqlConnection = require("../utils/database.js");
+const db = require("../models");
 const apiMessage = require("../utils/messages.js");
 
 // Setup the express server routeRoles
 const routeSpecies = express.Router();
 
 routeSpecies.get("/api/species", [auth, clinic], async (request, response) => {
-  var query = `SELECT speciesId, speciesName, speciesOrder FROM ${process.env.MYSQL_D_B_}.Species
-            ORDER BY speciesOrder, speciesName`;
-  mysqlConnection.getConnection(function (err, connection) {
-    if (err) {
+  const funcName = arguments.callee.name + "routeSpecies.get(";
+  const apiUrl = "/api/species|";
+  setLog("TRACE", __filename, funcName, apiUrl);
+  // var query = `SELECT speciesId, speciesName, speciesOrder FROM ${process.env.MYSQL_D_B_}.Species ORDER BY speciesOrder, speciesName`;
+  db.species.findAll({
+    attributes: ['speciesId', 'speciesName', 'speciesOrder'],
+    order: ['speciesOrder', 'speciesName'],
+  })
+    .then((rows) => {
+      setLog("DEBUG", __filename, funcName, `${apiUrl}.rows:${JSON.stringify(rows)}`);
+      response.send(rows);
+    })
+    .catch((err) => {
       response.status(501).json({
         message: apiMessage["501"][1],
         ok: false,
         error: err,
       });
-      return;
-    }
-    mysqlConnection.query(query, (err, rows, fields) => {
-      connection.release();
-      if (err) {
-        response.status(501).json({
-          message: apiMessage["501"][1],
-          ok: false,
-          error: err,
-        });
-      }
-      response.send(rows);
+      setLog("ERROR", __filename, funcName, `${apiUrl}.error:${JSON.stringify(err)}`);
+    })
+    .finally(() => {
+      setLog("INFO", __filename, funcName, `(${apiUrl}).end`);
     });
-    connection.on("error", function (err) {
-      return;
-    });
-  });
+  
   // To Test in Postman use a GET with this URL "http://localhost:49146/api/employee"
   // in "Body" use none
 });

--- a/api/app/routes/state.routes.js
+++ b/api/app/routes/state.routes.js
@@ -8,7 +8,7 @@ const setLog = require("../utils/logs.utils.js");
 
 routeState.get("/api/state", async (request, response) => {
   const funcName = arguments.callee.name + "routeState.get(";
-  const apiUrl = "/api/state/|";
+  const apiUrl = "/api/state|";
   setLog("TRACE", __filename, funcName, apiUrl);
   //var query = `SELECT stateId, stateName FROM ${process.env.MYSQL_D_B_}.States ORDER BY stateName`;
   db.state.findAll({
@@ -16,6 +16,7 @@ routeState.get("/api/state", async (request, response) => {
     order: ['stateName'],
   })
     .then((rows) => {
+      setLog("DEBUG", __filename, funcName, `${apiUrl}.rows:${JSON.stringify(rows)}`);
       response.send(rows);
     })
     .catch((err) => {
@@ -26,9 +27,7 @@ routeState.get("/api/state", async (request, response) => {
       });
       setLog("ERROR", __filename, funcName, `${apiUrl}.error:${JSON.stringify(err)}`);
     })
-    .finally(() => {
-      setLog("INFO", __filename, funcName, `(${apiUrl}).end`);
-    });
+    .finally(() => { setLog("INFO", __filename, funcName, `(${apiUrl}).end`); });
 
   // To Test in Postman use a GET with this URL "http://localhost:49146/api/employee"
   // in "Body" use none

--- a/api/app/routes/testType.routes.js
+++ b/api/app/routes/testType.routes.js
@@ -1,48 +1,41 @@
 const express = require("express");
+const { Op } = require("sequelize");
 
 // Import middlewares
 const auth = require("../middleware/auth.js");
 const { admin, laboratory, clinic } = require("../middleware/roles.js");
-const mysqlConnection = require("../utils/database.js");
+const db = require("../models");
 const apiMessage = require("../utils/messages.js");
 
 // Setup the express server routeRoles
 const routeTestType = express.Router();
 
-routeTestType.get(
-  "/api/testtype",
-  [auth, clinic],
-  async (request, response) => {
-    var query = `SELECT testTypeId, testTypeName, testTypeIsMultiple FROM ${process.env.MYSQL_D_B_}.testTypes
-            WHERE testTypeId >0
-            ORDER BY testTypeId`;
-    mysqlConnection.getConnection(function (err, connection) {
-      if (err) {
-        response.status(501).json({
-          message: apiMessage["501"][1],
-          ok: false,
-          error: err,
-        });
-        return;
-      }
-      mysqlConnection.query(query, (err, rows, fields) => {
-        connection.release();
-        if (err) {
-          response.status(501).json({
-            message: apiMessage["501"][1],
-            ok: false,
-            error: err,
-          });
-        }
-        response.send(rows);
+routeTestType.get("/api/testtype", [auth, clinic], async (request, response) => {
+  const funcName = arguments.callee.name + "routeTestType.get(";
+  const apiUrl = "/api/testtype|";
+  setLog("TRACE", __filename, funcName, apiUrl);
+  // var query = `SELECT testTypeId, testTypeName, testTypeIsMultiple FROM ${process.env.MYSQL_D_B_}.testTypes WHERE testTypeId >0 ORDER BY testTypeId`;
+  db.testType.findAll({
+    attributes: ['testTypeId', 'testTypeName', 'testTypeIsMultiple'],
+    where: { testTypeId: { [Op.gt]: 0 } /*>0*/ },
+    order: ['testTypeId'],
+  })
+    .then((rows) => {
+      setLog("DEBUG", __filename, funcName, `${apiUrl}.rows:${JSON.stringify(rows)}`);
+      response.send(rows);
+    })
+    .catch((err) => {
+      response.status(501).json({
+        message: apiMessage["501"][1],
+        ok: false,
+        error: err,
       });
-      connection.on("error", function (err) {
-        return;
-      });
-    });
-    // To Test in Postman use a GET with this URL "http://localhost:49146/api/employee"
-    // in "Body" use none
-  }
-);
+      setLog("ERROR", __filename, funcName, `${apiUrl}.error:${JSON.stringify(err)}`);
+    })
+    .finally(() => { setLog("INFO", __filename, funcName, `(${apiUrl}).end`);  });
+
+  // To Test in Postman use a GET with this URL "http://localhost:49146/api/employee"
+  // in "Body" use none
+});
 
 module.exports = routeTestType;


### PR DESCRIPTION

- 'sequelize' in 'testTypes.routes instead of 'mysqlConnection'.
- 'sequelize' in 'typeOfSample.routes instead of 'mysqlConnection'.
- Calling in 'model/index' first the new models before the 'belongsToMany'.

#20230823a